### PR TITLE
Fix drum mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ http://www.wiinupro.com/
 * This application supports the Classic Controller and Classic Controller Pro extensions as well. When using these, the buttons are mapped to the corresponding Xbox 360 gamepad buttons.
 * **The touch bar is not supported in this application because the Wii touch bars use even worse technology than the Xbox 360 touch bars and nobody likes them and Clone Hero doesn't support them.**
 * The tilt functionality actually comes **from the Wiimote** on Wiitars so changing Wiimotes will actually change your tilt sensitivity and responsiveness as Wiimote accelerometers are very inconsistently produced.
-* This application maps Wiidrums orange and green pads to a same Xbox 360 gamepad button, since Clone Hero currently only supports 4-lane drums. If Clone Hero adds Rock Band Pro Drums support, or Guitar Hero 5-lane drums support, this application will we updated to accommodate to those changes.
 
 ### Getting More Help If Needed
 Consult the `#help-line` channel in the [official Clone Hero server on Discord](https://discordapp.com/invite/Hsn4Cgu) if you need help following the instructions, advice on what to buy, or any other questions.

--- a/WiitarThing/Holders/XInputHolder.cs
+++ b/WiitarThing/Holders/XInputHolder.cs
@@ -284,12 +284,11 @@ namespace WiinUSoft.Holders
                     break;
 
                 case ControllerType.Drums:
-                    //TODO: When Clone Hero adds pro drums support, separate Green and Orange pads.
                     result.Add(Inputs.WiiDrums.G, Inputs.Xbox360.A);
                     result.Add(Inputs.WiiDrums.R, Inputs.Xbox360.B);
                     result.Add(Inputs.WiiDrums.Y, Inputs.Xbox360.Y);
                     result.Add(Inputs.WiiDrums.B, Inputs.Xbox360.X);
-                    result.Add(Inputs.WiiDrums.O, Inputs.Xbox360.A);
+                    result.Add(Inputs.WiiDrums.O, Inputs.Xbox360.RB);
                     result.Add(Inputs.WiiDrums.BASS, Inputs.Xbox360.LB);
 
                     result.Add(Inputs.WiiDrums.UP, Inputs.Xbox360.UP);


### PR DESCRIPTION
Set the orange cymbal and green pad mappings for drums to separate buttons, as well as remove the TODO comment that says to do this.

The readme has been updated to reflect this.