### PR TITLE
Native import fixes and cleanup (mostly for Bluetooth imports)

### DIFF
--- a/Shared/Shared.projitems
+++ b/Shared/Shared.projitems
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DeviceInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DummyDevice.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows\BluetoothDevice.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\BluetoothRadio.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\DeviceListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\NativeImports.cs" />

--- a/Shared/Shared.projitems
+++ b/Shared/Shared.projitems
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DeviceInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DummyDevice.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows\BluetoothRadio.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\DeviceListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\NativeImports.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\WinBtStream.cs" />

--- a/Shared/Windows/BluetoothDevice.cs
+++ b/Shared/Windows/BluetoothDevice.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+using System.Collections.Generic;
+
+namespace Shared.Windows
+{
+    using static NativeImports;
+
+    public class BluetoothDevice
+    {
+        private BluetoothRadio radio;
+        private BLUETOOTH_DEVICE_INFO info;
+
+        public string Name => info.szName;
+        public ulong Address => info.Address;
+        public uint DeviceClass => info.ulClassofDevice;
+        public bool Connected => info.fConnected;
+        public bool Remembered => info.fRemembered;
+        public bool Authenticated => info.fAuthenticated;
+        public DateTime LastSeen { get; }
+        public DateTime LastUsed { get; }
+
+        internal BluetoothDevice(BluetoothRadio radio, BLUETOOTH_DEVICE_INFO info)
+        {
+            this.radio = radio;
+            this.info = info;
+
+            LastSeen = new DateTime(info.stLastSeen.Year, info.stLastSeen.Month, info.stLastSeen.Day, info.stLastSeen.Hour, info.stLastSeen.Minute, info.stLastSeen.Second, info.stLastSeen.Milliseconds);
+            LastUsed = new DateTime(info.stLastUsed.Year, info.stLastUsed.Month, info.stLastUsed.Day, info.stLastUsed.Hour, info.stLastUsed.Minute, info.stLastUsed.Second, info.stLastUsed.Milliseconds);
+        }
+
+        public uint Authenticate(string password)
+        {
+            return radio.AuthenticateDevice(in info, password);
+        }
+
+        public uint Remove()
+        {
+            return NativeImports.BluetoothRemoveDevice(in info.Address);
+        }
+
+        public uint EnumerateInstalledServices(out Guid[] serviceGuids)
+        {
+            return radio.EnumerateInstalledServices(in info, out serviceGuids);
+        }
+
+        public uint SetServiceState(Guid serviceGuid, bool enable)
+        {
+            return radio.SetServiceState(in info, serviceGuid, enable);
+        }
+    }
+}

--- a/Shared/Windows/BluetoothDevice.cs
+++ b/Shared/Windows/BluetoothDevice.cs
@@ -33,21 +33,33 @@ namespace Shared.Windows
             LastUsed = new DateTime(info.stLastUsed.Year, info.stLastUsed.Month, info.stLastUsed.Day, info.stLastUsed.Hour, info.stLastUsed.Minute, info.stLastUsed.Second, info.stLastUsed.Milliseconds);
         }
 
+        /// <summary>
+        /// Authenticates this device with the given password.
+        /// </summary>
         public uint Authenticate(string password)
         {
             return radio.AuthenticateDevice(in info, password);
         }
 
+        /// <summary>
+        /// Removes this device from the system.
+        /// </summary>
         public uint Remove()
         {
             return NativeImports.BluetoothRemoveDevice(in info.Address);
         }
 
+        /// <summary>
+        /// Gets an array of all enabled services on this device.
+        /// </summary>
         public uint EnumerateInstalledServices(out Guid[] serviceGuids)
         {
             return radio.EnumerateInstalledServices(in info, out serviceGuids);
         }
 
+        /// <summary>
+        /// Sets the state of a service on this device.
+        /// </summary>
         public uint SetServiceState(Guid serviceGuid, bool enable)
         {
             return radio.SetServiceState(in info, serviceGuid, enable);

--- a/Shared/Windows/BluetoothRadio.cs
+++ b/Shared/Windows/BluetoothRadio.cs
@@ -56,7 +56,7 @@ namespace Shared.Windows
             return result == 0;
         }
 
-        public List<BLUETOOTH_DEVICE_INFO> FindAllDevices(
+        public List<BluetoothDevice> FindAllDevices(
             bool includeUnknown = true, bool includeConnected = true, bool includeRemembered = true,
             bool includeAuthenticated = true, bool issueInquiry = true, byte timeoutMultiplier = 2)
         {
@@ -74,14 +74,14 @@ namespace Shared.Windows
             searchParams.cTimeoutMultiplier = timeoutMultiplier;
 
             // Search for devices
-            var devices = new List<BLUETOOTH_DEVICE_INFO>();
+            var devices = new List<BluetoothDevice>();
             var deviceInfo = BLUETOOTH_DEVICE_INFO.Create();
             IntPtr searchHandle = NativeImports.BluetoothFindFirstDevice(in searchParams, ref deviceInfo);
 
             bool more = searchHandle != IntPtr.Zero;
             while (more)
             {
-                devices.Add(deviceInfo);
+                devices.Add(new BluetoothDevice(this, deviceInfo));
                 more = NativeImports.BluetoothFindNextDevice(searchHandle, ref deviceInfo);
             }
 

--- a/Shared/Windows/BluetoothRadio.cs
+++ b/Shared/Windows/BluetoothRadio.cs
@@ -1,0 +1,133 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+using System.Collections.Generic;
+
+namespace Shared.Windows
+{
+    using static NativeImports;
+
+    public class BluetoothRadio : IDisposable
+    {
+        private IntPtr handle;
+
+        public static List<BluetoothRadio> FindAllRadios()
+        {
+            var btRadios = new List<BluetoothRadio>();
+
+            var radioParams = BLUETOOTH_FIND_RADIO_PARAMS.Create();
+            var searchHandle = NativeImports.BluetoothFindFirstRadio(in radioParams, out IntPtr radioHandle);
+
+            bool moreDevices = searchHandle != IntPtr.Zero && radioHandle != IntPtr.Zero;
+            while (moreDevices)
+            {
+                if (radioHandle != IntPtr.Zero)
+                {
+                    btRadios.Add(new BluetoothRadio(radioHandle));
+                }
+
+                moreDevices = NativeImports.BluetoothFindNextRadio(searchHandle, out radioHandle);
+            }
+
+            if (searchHandle != IntPtr.Zero)
+                NativeImports.BluetoothFindRadioClose(searchHandle);
+
+            return btRadios;
+        }
+
+        private BluetoothRadio(IntPtr radioHandle)
+        {
+            handle = radioHandle;
+        }
+
+        ~BluetoothRadio()
+        {
+            Dispose(disposing: false);
+        }
+
+        public bool TryGetInfo(out BLUETOOTH_RADIO_INFO radioInfo)
+        {
+            radioInfo = BLUETOOTH_RADIO_INFO.Create();
+            uint result = NativeImports.BluetoothGetRadioInfo(handle, ref radioInfo);
+
+            return result == 0;
+        }
+
+        public List<BLUETOOTH_DEVICE_INFO> FindAllDevices(
+            bool includeUnknown = true, bool includeConnected = true, bool includeRemembered = true,
+            bool includeAuthenticated = true, bool issueInquiry = true, byte timeoutMultiplier = 2)
+        {
+            if (!TryGetInfo(out _))
+                return null;
+
+            // Set search parameters
+            var searchParams = BLUETOOTH_DEVICE_SEARCH_PARAMS.Create();
+            searchParams.hRadio = handle;
+            searchParams.fIssueInquiry = issueInquiry;
+            searchParams.fReturnUnknown = includeUnknown;
+            searchParams.fReturnConnected = includeConnected;
+            searchParams.fReturnRemembered = includeRemembered;
+            searchParams.fReturnAuthenticated = includeAuthenticated;
+            searchParams.cTimeoutMultiplier = timeoutMultiplier;
+
+            // Search for devices
+            var devices = new List<BLUETOOTH_DEVICE_INFO>();
+            var deviceInfo = BLUETOOTH_DEVICE_INFO.Create();
+            IntPtr searchHandle = NativeImports.BluetoothFindFirstDevice(in searchParams, ref deviceInfo);
+
+            bool more = searchHandle != IntPtr.Zero;
+            while (more)
+            {
+                devices.Add(deviceInfo);
+                more = NativeImports.BluetoothFindNextDevice(searchHandle, ref deviceInfo);
+            }
+
+            if (searchHandle != IntPtr.Zero)
+                NativeImports.BluetoothFindDeviceClose(searchHandle);
+
+            return devices;
+        }
+
+        public uint AuthenticateDevice(in BLUETOOTH_DEVICE_INFO deviceInfo, string password)
+        {
+            return NativeImports.BluetoothAuthenticateDevice(IntPtr.Zero, handle, in deviceInfo, password, (uint)password.Length);
+        }
+
+        public uint EnumerateInstalledServices(in BLUETOOTH_DEVICE_INFO deviceInfo, out Guid[] serviceGuids)
+        {
+            uint serviceCount = 0;
+            uint result = NativeImports.BluetoothEnumerateInstalledServices(handle, in deviceInfo, ref serviceCount, null);
+            if (result != 0 || serviceCount == 0)
+            {
+                serviceGuids = null;
+                return result;
+            }
+
+            serviceGuids = new Guid[serviceCount];
+            return NativeImports.BluetoothEnumerateInstalledServices(handle, in deviceInfo, ref serviceCount, serviceGuids);
+        }
+
+        public uint SetServiceState(in BLUETOOTH_DEVICE_INFO deviceInfo, Guid serviceGuid, bool enable)
+        {
+            return NativeImports.BluetoothSetServiceState(handle, in deviceInfo, in serviceGuid, enable ? BluetoothServiceFlag.Enable : BluetoothServiceFlag.Disable);
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool disposing)
+        {
+            if (handle != IntPtr.Zero)
+            {
+                NativeImports.CloseHandle(handle);
+                handle = IntPtr.Zero;
+            }
+        }
+    }
+}

--- a/Shared/Windows/NativeImports.cs
+++ b/Shared/Windows/NativeImports.cs
@@ -222,6 +222,9 @@ namespace Shared.Windows
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern uint BluetoothRemoveDevice(in ulong pAddress);
 
+        [DllImport("bthprops.cpl", SetLastError = true)]
+        public static extern bool BluetoothFindDeviceClose(IntPtr hFind);
+
         [DllImport("bthprops.cpl", SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern uint BluetoothAuthenticateDevice(
             IntPtr hwndParent, 

--- a/Shared/Windows/NativeImports.cs
+++ b/Shared/Windows/NativeImports.cs
@@ -20,11 +20,11 @@ namespace Shared.Windows
         [DllImport("kernel32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public extern static bool WriteFile(
-            IntPtr hFile,                    // HANDLE
+            SafeFileHandle hFile,            // HANDLE
             byte[] lpBuffer,                 // LPCVOID
             uint nNumberOfBytesToWrite,      // DWORD
             out uint lpNumberOfBytesWritten, // LPDWORD
-            [In] ref NativeOverlapped lpOverlapped);
+            ref NativeOverlapped lpOverlapped);
 
 
         /// <summary>
@@ -33,24 +33,25 @@ namespace Shared.Windows
         public delegate void WriteFileCompletionDelegate(
             uint dwErrorCode, 
             uint dwNumberOfBytesTransfered, 
-            NativeOverlapped lpOverlapped);
+            ref NativeOverlapped lpOverlapped);
 
         /// <summary>
         /// Like WriteFile but provides an asynchronous callback
         /// </summary>
         [DllImport("kernel32.dll", SetLastError = true)]
         public extern static bool WriteFileEx(
-            IntPtr hFile, 
+            SafeFileHandle hFile, 
             byte[] lpBuffer,
             uint nNumberOfBytesToWrite, 
-            [In] ref NativeOverlapped lpOverlapped,
+            ref NativeOverlapped lpOverlapped,
             WriteFileCompletionDelegate lpCompletionRoutine);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         public extern static bool ReadFile(
-            IntPtr hFile,
+            SafeFileHandle hFile,
             byte[] lpBuffer,
             uint nNumberofBytesToRead,
+            out uint lpNumberOfBytesRead,
             ref NativeOverlapped lpOverlapped);
 
         /// <summary>
@@ -67,7 +68,7 @@ namespace Shared.Windows
             IntPtr securityAttributes,
             [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
             [MarshalAs(UnmanagedType.U4)] EFileAttributes flags,
-            IntPtr template);
+            SafeFileHandle template);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/Shared/Windows/NativeImports.cs
+++ b/Shared/Windows/NativeImports.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -203,20 +203,20 @@ namespace Shared.Windows
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern IntPtr BluetoothFindFirstRadio(
-            ref BLUETOOTH_FIND_RADIO_PARAMS pbtfrp, 
+            in BLUETOOTH_FIND_RADIO_PARAMS pbtfrp, 
             out IntPtr phRadio);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern bool BluetoothFindNextRadio(
-            ref BLUETOOTH_FIND_RADIO_PARAMS hFind, 
+            IntPtr hFind, 
             out IntPtr phRadio);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
-        public static extern bool BluetoothFindRadioClose(ref IntPtr hFind);
+        public static extern bool BluetoothFindRadioClose(IntPtr hFind);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern IntPtr BluetoothFindFirstDevice(
-            ref BLUETOOTH_DEVICE_SEARCH_PARAMS searchParams, 
+            in BLUETOOTH_DEVICE_SEARCH_PARAMS searchParams, 
             ref BLUETOOTH_DEVICE_INFO deviceInfo);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
@@ -225,14 +225,14 @@ namespace Shared.Windows
             ref BLUETOOTH_DEVICE_INFO pbtdi);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
-        public static extern uint BluetoothRemoveDevice(ref ulong pAddress);
+        public static extern uint BluetoothRemoveDevice(in ulong pAddress);
 
         [DllImport("bthprops.cpl", SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern uint BluetoothAuthenticateDevice(
             IntPtr hwndParent, 
             IntPtr hRadio, 
-            ref BLUETOOTH_DEVICE_INFO pbtdi, 
-            [MarshalAs(UnmanagedType.LPWStr)]string pszPasskey, 
+            in BLUETOOTH_DEVICE_INFO pbtdi, 
+            [MarshalAs(UnmanagedType.LPWStr)] string pszPasskey, 
             ulong ulPasskeyLength);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
@@ -240,24 +240,24 @@ namespace Shared.Windows
             IntPtr hwndParentIn, 
             IntPtr hRadioIn, 
             ref BLUETOOTH_DEVICE_INFO pbtdiInout, 
-            /*BLUETOOTH_OOB_DATA*/ object pbtOobData,
+            in BLUETOOTH_OOB_DATA_INFO pbtOobData,
             AUTHENTICATION_REQUIREMENTS authenticationRequirement);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern uint BluetoothEnumerateInstalledServices(
             IntPtr hRadio, 
-            ref BLUETOOTH_DEVICE_INFO pbtdi, 
-            ref uint pcServices, 
+            in BLUETOOTH_DEVICE_INFO pbtdi, 
+            ref uint pcServiceInout, 
             Guid[] pGuidServices);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern uint BluetoothSetServiceState(
             IntPtr hRadio, 
-            ref BLUETOOTH_DEVICE_INFO pbtdi, 
-            ref Guid pGuidService, 
-            byte dwServiceFlags);
+            in BLUETOOTH_DEVICE_INFO pbtdi, 
+            in Guid pGuidService, 
+            int dwServiceFlags);
 
-        [DllImport("bthprops.cpl", EntryPoint = "BluetoothEnableDiscovery", SetLastError = true)]
+        [DllImport("bthprops.cpl", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool BluetoothEnableDiscovery(
             IntPtr hRadio,
@@ -288,9 +288,12 @@ namespace Shared.Windows
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 248)]
             public string szName;
 
-            public void Initialize()
+            public static BLUETOOTH_DEVICE_INFO Create()
             {
-                this.dwSize = (uint)Marshal.SizeOf(typeof(BLUETOOTH_DEVICE_INFO));
+                return new BLUETOOTH_DEVICE_INFO()
+                {
+                    dwSize = (uint)Marshal.SizeOf(typeof(BLUETOOTH_DEVICE_INFO))
+                };
             }
         }
 
@@ -340,9 +343,12 @@ namespace Shared.Windows
             internal byte cTimeoutMultiplier;
             internal IntPtr hRadio;
 
-            internal void Initialize()
+            internal static BLUETOOTH_DEVICE_SEARCH_PARAMS Create()
             {
-                this.dwSize = (uint)Marshal.SizeOf(typeof(BLUETOOTH_DEVICE_SEARCH_PARAMS));
+                return new BLUETOOTH_DEVICE_SEARCH_PARAMS()
+                {
+                    dwSize = (uint)Marshal.SizeOf(typeof(BLUETOOTH_DEVICE_SEARCH_PARAMS))
+                };
             }
         }
         #endregion
@@ -395,9 +401,13 @@ namespace Shared.Windows
         public struct BLUETOOTH_FIND_RADIO_PARAMS
         {
             internal uint dwSize;
-            internal void Initialize()
+
+            internal static BLUETOOTH_FIND_RADIO_PARAMS Create()
             {
-                this.dwSize = (uint)Marshal.SizeOf(typeof(BLUETOOTH_FIND_RADIO_PARAMS));
+                return new BLUETOOTH_FIND_RADIO_PARAMS()
+                {
+                    dwSize = (uint)Marshal.SizeOf(typeof(BLUETOOTH_FIND_RADIO_PARAMS))
+                };
             }
         }
 
@@ -425,10 +435,23 @@ namespace Shared.Windows
                 }
             }
 
-            internal void Initialize()
+            internal static BLUETOOTH_RADIO_INFO Create()
             {
-                this.dwSize = (uint)Marshal.SizeOf(typeof(BLUETOOTH_RADIO_INFO));
+                return new BLUETOOTH_RADIO_INFO()
+                {
+                    dwSize = (uint)Marshal.SizeOf(typeof(BLUETOOTH_RADIO_INFO))
+                };
             }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct BLUETOOTH_OOB_DATA_INFO
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public byte[] C;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public byte[] R;
         }
         #endregion
 

--- a/Shared/Windows/NativeImports.cs
+++ b/Shared/Windows/NativeImports.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -193,30 +193,30 @@ namespace Shared.Windows
         #region bthprops.cpl
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern uint BluetoothGetRadioInfo(
-            IntPtr hRadio, 
+            SafeObjectHandle hRadio, 
             ref BLUETOOTH_RADIO_INFO pRadioInfo);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
-        public static extern IntPtr BluetoothFindFirstRadio(
+        public static extern SafeBluetoothRadioHandle BluetoothFindFirstRadio(
             in BLUETOOTH_FIND_RADIO_PARAMS pbtfrp, 
-            out IntPtr phRadio);
+            out SafeObjectHandle phRadio);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern bool BluetoothFindNextRadio(
-            IntPtr hFind, 
-            out IntPtr phRadio);
+            SafeBluetoothRadioHandle hFind, 
+            out SafeObjectHandle phRadio);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern bool BluetoothFindRadioClose(IntPtr hFind);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
-        public static extern IntPtr BluetoothFindFirstDevice(
+        public static extern SafeBluetoothDeviceHandle BluetoothFindFirstDevice(
             in BLUETOOTH_DEVICE_SEARCH_PARAMS searchParams, 
             ref BLUETOOTH_DEVICE_INFO deviceInfo);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern bool BluetoothFindNextDevice(
-            IntPtr hFind, 
+            SafeBluetoothDeviceHandle hFind, 
             ref BLUETOOTH_DEVICE_INFO pbtdi);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
@@ -228,7 +228,7 @@ namespace Shared.Windows
         [DllImport("bthprops.cpl", SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern uint BluetoothAuthenticateDevice(
             IntPtr hwndParent, 
-            IntPtr hRadio, 
+            SafeObjectHandle hRadio, 
             in BLUETOOTH_DEVICE_INFO pbtdi, 
             [MarshalAs(UnmanagedType.LPWStr)] string pszPasskey, 
             uint ulPasskeyLength);
@@ -236,21 +236,21 @@ namespace Shared.Windows
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern uint BluetoothAuthenticateDeviceEx(
             IntPtr hwndParentIn, 
-            IntPtr hRadioIn, 
+            SafeObjectHandle hRadioIn, 
             ref BLUETOOTH_DEVICE_INFO pbtdiInout, 
             in BLUETOOTH_OOB_DATA_INFO pbtOobData,
             AUTHENTICATION_REQUIREMENTS authenticationRequirement);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern uint BluetoothEnumerateInstalledServices(
-            IntPtr hRadio, 
+            SafeObjectHandle hRadio, 
             in BLUETOOTH_DEVICE_INFO pbtdi, 
             ref uint pcServiceInout, 
             Guid[] pGuidServices);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern uint BluetoothSetServiceState(
-            IntPtr hRadio, 
+            SafeObjectHandle hRadio, 
             in BLUETOOTH_DEVICE_INFO pbtdi, 
             in Guid pGuidService, 
             [MarshalAs(UnmanagedType.U4)] BluetoothServiceFlag dwServiceFlags);
@@ -258,7 +258,7 @@ namespace Shared.Windows
         [DllImport("bthprops.cpl", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool BluetoothEnableDiscovery(
-            IntPtr hRadio,
+            SafeObjectHandle hRadio,
             [MarshalAs(UnmanagedType.Bool)] bool fEnabled);
 
         public enum AUTHENTICATION_REQUIREMENTS : uint
@@ -525,6 +525,70 @@ namespace Shared.Windows
         {
             Disable = 0x00,
             Enable = 0x01
+        }
+
+        #endregion
+
+        #region Safe Handles
+
+        /// <summary>
+        /// A generic safe handle for any handle that is closed via CloseHandle.
+        /// </summary>
+        public class SafeObjectHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            public SafeObjectHandle() : base(true)
+            {
+            }
+
+            public SafeObjectHandle(IntPtr existingHandle, bool ownsHandle) : base(ownsHandle)
+            {
+                SetHandle(existingHandle);
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return CloseHandle(handle);
+            }
+        }
+
+        /// <summary>
+        /// A safe handle for Bluetooth radio searches (handles returned by BluetoothFindFirstRadio).
+        /// </summary>
+        public class SafeBluetoothRadioHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            public SafeBluetoothRadioHandle() : base(true)
+            {
+            }
+
+            public SafeBluetoothRadioHandle(IntPtr existingHandle, bool ownsHandle) : base(ownsHandle)
+            {
+                SetHandle(existingHandle);
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return BluetoothFindRadioClose(handle);
+            }
+        }
+
+        /// <summary>
+        /// A safe handle for Bluetooth device searches (handles returned by BluetoothFindFirstDevice).
+        /// </summary>
+        public class SafeBluetoothDeviceHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            public SafeBluetoothDeviceHandle() : base(true)
+            {
+            }
+
+            public SafeBluetoothDeviceHandle(IntPtr existingHandle, bool ownsHandle) : base(ownsHandle)
+            {
+                SetHandle(existingHandle);
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return BluetoothFindDeviceClose(handle);
+            }
         }
 
         #endregion

--- a/Shared/Windows/NativeImports.cs
+++ b/Shared/Windows/NativeImports.cs
@@ -54,12 +54,6 @@ namespace Shared.Windows
             out uint lpNumberOfBytesRead,
             ref NativeOverlapped lpOverlapped);
 
-        /// <summary>
-        /// Used to Get the error code after WriteFile
-        /// </summary>
-        [DllImport("kernel32.dll")]
-        public extern static uint GetLastError();
-
         [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         public static extern SafeFileHandle CreateFile(
             string fileName,

--- a/Shared/Windows/NativeImports.cs
+++ b/Shared/Windows/NativeImports.cs
@@ -253,7 +253,7 @@ namespace Shared.Windows
             IntPtr hRadio, 
             in BLUETOOTH_DEVICE_INFO pbtdi, 
             in Guid pGuidService, 
-            int dwServiceFlags);
+            [MarshalAs(UnmanagedType.U4)] BluetoothServiceFlag dwServiceFlags);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -517,6 +517,13 @@ namespace Shared.Windows
             OpenReparsePoint  = 0x00200000,
             OpenNoRecall      = 0x00100000,
             FirstPipeInstance = 0x00080000
+        }
+
+        [Flags]
+        public enum BluetoothServiceFlag : uint
+        {
+            Disable = 0x00,
+            Enable = 0x01
         }
 
         #endregion

--- a/Shared/Windows/NativeImports.cs
+++ b/Shared/Windows/NativeImports.cs
@@ -231,7 +231,7 @@ namespace Shared.Windows
             IntPtr hRadio, 
             in BLUETOOTH_DEVICE_INFO pbtdi, 
             [MarshalAs(UnmanagedType.LPWStr)] string pszPasskey, 
-            ulong ulPasskeyLength);
+            uint ulPasskeyLength);
 
         [DllImport("bthprops.cpl", SetLastError = true)]
         public static extern uint BluetoothAuthenticateDeviceEx(

--- a/Shared/Windows/NativeImports.cs
+++ b/Shared/Windows/NativeImports.cs
@@ -62,7 +62,7 @@ namespace Shared.Windows
             IntPtr securityAttributes,
             [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
             [MarshalAs(UnmanagedType.U4)] EFileAttributes flags,
-            SafeFileHandle template);
+            IntPtr template);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/Shared/Windows/NativeImports.cs
+++ b/Shared/Windows/NativeImports.cs
@@ -380,6 +380,7 @@ namespace Shared.Windows
             public string devicePath;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
         public struct DEVPROPKEY
         {
             public Guid fmtid;

--- a/Shared/Windows/WinBtStream.cs
+++ b/Shared/Windows/WinBtStream.cs
@@ -1,4 +1,4 @@
-/* * * * * * * * * * * * * * * * * * * * * * * * * * *
+﻿/* * * * * * * * * * * * * * * * * * * * * * * * * * *
  * === Notes ===
  * 
  * - When using the Toshiba Stack,
@@ -224,7 +224,7 @@ namespace Shared.Windows
             }
             else
             {
-                var error = GetLastError();
+                var error = Marshal.GetLastWin32Error();
                 SetupDiDestroyDeviceInfoList(parentDeviceInfo);
             }
 
@@ -388,7 +388,7 @@ namespace Shared.Windows
                     {
                         System.Diagnostics.Debug.WriteLine("caught!");
                     }
-                    uint error = GetLastError();
+                    int error = Marshal.GetLastWin32Error();
 
                     // Wait for the async operation to complete
                     if (!success && error == 997)

--- a/Shared/Windows/WinBtStream.cs
+++ b/Shared/Windows/WinBtStream.cs
@@ -1,4 +1,4 @@
-﻿/* * * * * * * * * * * * * * * * * * * * * * * * * * *
+/* * * * * * * * * * * * * * * * * * * * * * * * * * *
  * === Notes ===
  * 
  * - When using the Toshiba Stack,
@@ -134,12 +134,12 @@ namespace Shared.Windows
             {
                 if (OverrideSharingMode)
                 {
-                    _fileHandle = CreateFile(_hidPath, FileAccess.ReadWrite, OverridenFileShare, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, IntPtr.Zero);
+                    _fileHandle = CreateFile(_hidPath, FileAccess.ReadWrite, OverridenFileShare, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, null);
                 }
                 else
                 {
                     // Open the file handle with the specified sharing mode and an overlapped file attribute flag for asynchronous operation
-                    _fileHandle = CreateFile(_hidPath, FileAccess.ReadWrite, SharingMode, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, IntPtr.Zero);
+                    _fileHandle = CreateFile(_hidPath, FileAccess.ReadWrite, SharingMode, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, null);
                 }
                 _fileStream = new FileStream(_fileHandle, FileAccess.ReadWrite, 22, true);
             }
@@ -266,7 +266,7 @@ namespace Shared.Windows
                 if (SetupDiGetDeviceInterfaceDetail(hDevInfo, ref diData, ref diDetail, size, out size, ref deviceInfoData))
                 {
                     // Open read/write handle
-                    handle = CreateFile(diDetail.devicePath, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, IntPtr.Zero);
+                    handle = CreateFile(diDetail.devicePath, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, null);
 
                     // Create Attributes Structure
                     HIDD_ATTRIBUTES attrib = new HIDD_ATTRIBUTES();
@@ -379,11 +379,10 @@ namespace Shared.Windows
                     nativeOverlap.EventHandle = resetEvent.SafeWaitHandle.DangerousGetHandle();
 
                     // success is most likely to be false which can mean it is being completed asynchronously, in this case we need to wait
-                    var dh = _fileHandle.DangerousGetHandle();
                     bool success = false;
                     try
                     {
-                        success = WriteFile(dh, buffer, (uint)buffer.Length, out written, ref nativeOverlap);
+                        success = WriteFile(_fileHandle, buffer, (uint)buffer.Length, out written, ref nativeOverlap);
                     }
                     catch
                     {

--- a/Shared/Windows/WinBtStream.cs
+++ b/Shared/Windows/WinBtStream.cs
@@ -134,12 +134,12 @@ namespace Shared.Windows
             {
                 if (OverrideSharingMode)
                 {
-                    _fileHandle = CreateFile(_hidPath, FileAccess.ReadWrite, OverridenFileShare, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, null);
+                    _fileHandle = CreateFile(_hidPath, FileAccess.ReadWrite, OverridenFileShare, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, IntPtr.Zero);
                 }
                 else
                 {
                     // Open the file handle with the specified sharing mode and an overlapped file attribute flag for asynchronous operation
-                    _fileHandle = CreateFile(_hidPath, FileAccess.ReadWrite, SharingMode, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, null);
+                    _fileHandle = CreateFile(_hidPath, FileAccess.ReadWrite, SharingMode, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, IntPtr.Zero);
                 }
                 _fileStream = new FileStream(_fileHandle, FileAccess.ReadWrite, 22, true);
             }
@@ -266,7 +266,7 @@ namespace Shared.Windows
                 if (SetupDiGetDeviceInterfaceDetail(hDevInfo, ref diData, ref diDetail, size, out size, ref deviceInfoData))
                 {
                     // Open read/write handle
-                    handle = CreateFile(diDetail.devicePath, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, null);
+                    handle = CreateFile(diDetail.devicePath, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, IntPtr.Zero);
 
                     // Create Attributes Structure
                     HIDD_ATTRIBUTES attrib = new HIDD_ATTRIBUTES();

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -172,7 +172,7 @@ namespace WiitarThing.Windows
                 // Search until cancelled or at least one device is paired
                 while (!Cancelled && Count == 0)
                 {
-                    foreach (var radio in btRadios) using (radio)
+                    foreach (var radio in btRadios)
                     {
                         // Get radio info
                         if (!radio.TryGetInfo(out var radioInfo))
@@ -309,6 +309,11 @@ namespace WiitarThing.Windows
                             }
                         }
                     }
+                }
+
+                foreach (var radio in btRadios)
+                {
+                    radio.Dispose();
                 }
             }
             else

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -154,7 +154,7 @@ namespace WiitarThing.Windows
             if (btRadios.Count < 1)
             {
                 // No compatible Bluetooth
-                Prompt("No compatible Bluetooth Radios found! (IF YOU SEE THIS MESSAGE, MENTION IT WHEN ASKING FOR HELP!)",
+                Prompt("No compatible Bluetooth Radios found, or Bluetooth is disabled! (IF YOU SEE THIS MESSAGE, MENTION IT WHEN ASKING FOR HELP!)",
                 isBold: true, isItalic: true);
                 _notCompatable = true;
                 return;

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -108,6 +108,9 @@ namespace WiitarThing.Windows
                 more = NativeImports.BluetoothFindNextRadio(foundResult, out foundRadio);
             } while (more);
 
+            if (foundResult != IntPtr.Zero)
+                NativeImports.BluetoothFindRadioClose(foundResult);
+
             if (btRadios.Count > 0)
             {
                 foreach (var radio in btRadios)
@@ -171,8 +174,18 @@ namespace WiitarThing.Windows
                                 }
 
                             } while (NativeImports.BluetoothFindNextDevice(found, ref deviceInfo));
+
+                            NativeImports.BluetoothFindDeviceClose(found);
                         }
                     }
+                }
+
+                // Close each Radio
+                foreach (var openRadio in btRadios)
+                {
+                    WiitarDebug.Log("BEF - CloseHandle");
+                    NativeImports.CloseHandle(openRadio);
+                    WiitarDebug.Log("AFT - CloseHandle");
                 }
             }
 
@@ -208,6 +221,9 @@ namespace WiitarThing.Windows
                 more = NativeImports.BluetoothFindNextRadio(foundResult, out foundRadio);
                 WiitarDebug.Log("AFT - BluetoothFindNextRadio");
             } while (more);
+
+            if (foundResult != IntPtr.Zero)
+                NativeImports.BluetoothFindRadioClose(foundResult);
 
             if (btRadios.Count > 0)
             {
@@ -447,6 +463,8 @@ namespace WiitarThing.Windows
 
                                     WiitarDebug.Log("About to try BluetoothFindNextDevice...");
                                 } while (NativeImports.BluetoothFindNextDevice(found, ref deviceInfo));
+
+                                NativeImports.BluetoothFindDeviceClose(found);
                             }
                         }
                         else

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -87,16 +87,14 @@ namespace WiitarThing.Windows
         {
             WiitarDebug.Log("FUNC BEGIN - RemoveAllWiimotes");
 
-            var radioParams = new NativeImports.BLUETOOTH_FIND_RADIO_PARAMS();
+            var radioParams = NativeImports.BLUETOOTH_FIND_RADIO_PARAMS.Create();
             Guid HidServiceClass = NativeImports.HidServiceClassGuid;
             List<IntPtr> btRadios = new List<IntPtr>();
             IntPtr foundRadio;
             IntPtr foundResult;
 
-            radioParams.Initialize();
-
             // Get first BT Radio
-            foundResult = NativeImports.BluetoothFindFirstRadio(ref radioParams, out foundRadio);
+            foundResult = NativeImports.BluetoothFindFirstRadio(in radioParams, out foundRadio);
             bool more = foundResult != IntPtr.Zero;
 
             do
@@ -107,7 +105,7 @@ namespace WiitarThing.Windows
                 }
 
                 // Find more
-                more = NativeImports.BluetoothFindNextRadio(ref radioParams, out foundRadio);
+                more = NativeImports.BluetoothFindNextRadio(foundResult, out foundRadio);
             } while (more);
 
             if (btRadios.Count > 0)
@@ -115,13 +113,9 @@ namespace WiitarThing.Windows
                 foreach (var radio in btRadios)
                 {
                     IntPtr found;
-                    var radioInfo = new NativeImports.BLUETOOTH_RADIO_INFO();
-                    var deviceInfo = new NativeImports.BLUETOOTH_DEVICE_INFO();
-                    var searchParams = new NativeImports.BLUETOOTH_DEVICE_SEARCH_PARAMS();
-
-                    radioInfo.Initialize();
-                    deviceInfo.Initialize();
-                    searchParams.Initialize();
+                    var radioInfo = NativeImports.BLUETOOTH_RADIO_INFO.Create();
+                    var deviceInfo = NativeImports.BLUETOOTH_DEVICE_INFO.Create();
+                    var searchParams = NativeImports.BLUETOOTH_DEVICE_SEARCH_PARAMS.Create();
 
                     // Access radio information
                     WiitarDebug.Log("BEF - BluetoothGetRadioInfo");
@@ -141,7 +135,7 @@ namespace WiitarThing.Windows
 
                         // Search for a device
                         WiitarDebug.Log("BEF - BluetoothFindFirstDevice");
-                        found = NativeImports.BluetoothFindFirstDevice(ref searchParams, ref deviceInfo);
+                        found = NativeImports.BluetoothFindFirstDevice(in searchParams, ref deviceInfo);
                         WiitarDebug.Log("AFT - BluetoothFindFirstDevice");
 
                         // Success
@@ -163,7 +157,7 @@ namespace WiitarThing.Windows
                                     if (/*!ConnectedDeviceAddresses.Contains(deviceInfo.Address) && */(deviceInfo.fRemembered || deviceInfo.fConnected))
                                     {
                                         WiitarDebug.Log("BEF - BluetoothRemoveDevice");
-                                        errForget = NativeImports.BluetoothRemoveDevice(ref deviceInfo.Address);
+                                        errForget = NativeImports.BluetoothRemoveDevice(in deviceInfo.Address);
                                         WiitarDebug.Log("AFT - BluetoothRemoveDevice");
                                         success = errForget == 0;
                                     }
@@ -190,18 +184,15 @@ namespace WiitarThing.Windows
             WiitarDebug.Log("FUNC BEGIN - Sync");
 
             WiitarDebug.Log("BEF - BLUETOOTH_FIND_RADIO_PARAMS");
-            var radioParams = new NativeImports.BLUETOOTH_FIND_RADIO_PARAMS();
+            var radioParams = NativeImports.BLUETOOTH_FIND_RADIO_PARAMS.Create();
             WiitarDebug.Log("AFT - BLUETOOTH_FIND_RADIO_PARAMS");
-            Guid HidServiceClass = NativeImports.HidServiceClassGuid;
             List<IntPtr> btRadios = new List<IntPtr>();
             IntPtr foundRadio;
             IntPtr foundResult;
 
-            radioParams.Initialize();
-
             // Get first BT Radio
             WiitarDebug.Log("BEF - BluetoothGetRadioInfo");
-            foundResult = NativeImports.BluetoothFindFirstRadio(ref radioParams, out foundRadio);
+            foundResult = NativeImports.BluetoothFindFirstRadio(in radioParams, out foundRadio);
             WiitarDebug.Log("AFT - BluetoothGetRadioInfo");
             bool more = foundResult != IntPtr.Zero;
 
@@ -214,7 +205,7 @@ namespace WiitarThing.Windows
 
                 // Find more
                 WiitarDebug.Log("BEF - BluetoothFindNextRadio");
-                more = NativeImports.BluetoothFindNextRadio(ref radioParams, out foundRadio);
+                more = NativeImports.BluetoothFindNextRadio(foundResult, out foundRadio);
                 WiitarDebug.Log("AFT - BluetoothFindNextRadio");
             } while (more);
 
@@ -230,20 +221,16 @@ namespace WiitarThing.Windows
                         IntPtr found;
 
                         WiitarDebug.Log("BEF - BLUETOOTH_RADIO_INFO");
-                        var radioInfo = new NativeImports.BLUETOOTH_RADIO_INFO();
+                        var radioInfo = NativeImports.BLUETOOTH_RADIO_INFO.Create();
                         WiitarDebug.Log("AFT - BLUETOOTH_RADIO_INFO");
 
                         WiitarDebug.Log("BEF - BLUETOOTH_DEVICE_INFO");
-                        var deviceInfo = new NativeImports.BLUETOOTH_DEVICE_INFO();
+                        var deviceInfo = NativeImports.BLUETOOTH_DEVICE_INFO.Create();
                         WiitarDebug.Log("AFT - BLUETOOTH_DEVICE_INFO");
 
                         WiitarDebug.Log("BEF - BLUETOOTH_DEVICE_SEARCH_PARAMS");
-                        var searchParams = new NativeImports.BLUETOOTH_DEVICE_SEARCH_PARAMS();
+                        var searchParams = NativeImports.BLUETOOTH_DEVICE_SEARCH_PARAMS.Create();
                         WiitarDebug.Log("AFT - BLUETOOTH_DEVICE_SEARCH_PARAMS");
-
-                        radioInfo.Initialize();
-                        deviceInfo.Initialize();
-                        searchParams.Initialize();
 
                         // Access radio information
                         WiitarDebug.Log("BEF - BluetoothGetRadioInfo");
@@ -264,7 +251,7 @@ namespace WiitarThing.Windows
 
                             // Search for a device
                             WiitarDebug.Log("BEF - BluetoothFindFirstDevice");
-                            found = NativeImports.BluetoothFindFirstDevice(ref searchParams, ref deviceInfo);
+                            found = NativeImports.BluetoothFindFirstDevice(in searchParams, ref deviceInfo);
                             WiitarDebug.Log("AFT - BluetoothFindFirstDevice");
 
                             // Success
@@ -362,9 +349,9 @@ namespace WiitarThing.Windows
                                         if (success)
                                         {
                                             WiitarDebug.Log("BEF - BluetoothAuthenticateDevice [SYNC]");
-                                            errAuth = NativeImports.BluetoothAuthenticateDevice(IntPtr.Zero, radio, ref deviceInfo, password.ToString(), 6);
+                                            errAuth = NativeImports.BluetoothAuthenticateDevice(IntPtr.Zero, radio, in deviceInfo, password.ToString(), 6);
                                             WiitarDebug.Log("AFT - BluetoothAuthenticateDevice [SYNC]");
-                                            //errAuth = NativeImports.BluetoothAuthenticateDeviceEx(IntPtr.Zero, radio, ref deviceInfo, null, NativeImports.AUTHENTICATION_REQUIREMENTS.MITMProtectionNotRequired);
+                                            //errAuth = NativeImports.BluetoothAuthenticateDeviceEx(IntPtr.Zero, radio, in deviceInfo, null, NativeImports.AUTHENTICATION_REQUIREMENTS.MITMProtectionNotRequired);
                                             success = errAuth == 0;
                                         }
 
@@ -386,10 +373,10 @@ namespace WiitarThing.Windows
                                             }
 
                                             WiitarDebug.Log("BEF - BluetoothAuthenticateDevice [1+2]");
-                                            errAuth = NativeImports.BluetoothAuthenticateDevice(IntPtr.Zero, radio, ref deviceInfo, password.ToString(), 6);
+                                            errAuth = NativeImports.BluetoothAuthenticateDevice(IntPtr.Zero, radio, in deviceInfo, password.ToString(), 6);
                                             WiitarDebug.Log("AFT - BluetoothAuthenticateDevice [1+2]");
 
-                                            //errAuth = NativeImports.BluetoothAuthenticateDeviceEx(IntPtr.Zero, radio, ref deviceInfo, null, NativeImports.AUTHENTICATION_REQUIREMENTS.MITMProtectionNotRequired);
+                                            //errAuth = NativeImports.BluetoothAuthenticateDeviceEx(IntPtr.Zero, radio, in deviceInfo, null, NativeImports.AUTHENTICATION_REQUIREMENTS.MITMProtectionNotRequired);
                                             success = errAuth == 0;
                                         }
 
@@ -397,7 +384,7 @@ namespace WiitarThing.Windows
                                         if (success)
                                         {
                                             WiitarDebug.Log("BEF - BluetoothEnumerateInstalledServices");
-                                            errService = NativeImports.BluetoothEnumerateInstalledServices(radio, ref deviceInfo, ref pcService, guids);
+                                            errService = NativeImports.BluetoothEnumerateInstalledServices(radio, in deviceInfo, ref pcService, guids);
                                             WiitarDebug.Log("AFT - BluetoothEnumerateInstalledServices");
                                             success = errService == 0;
                                         }
@@ -406,7 +393,7 @@ namespace WiitarThing.Windows
                                         if (success)
                                         {
                                             WiitarDebug.Log("BEF - BluetoothSetServiceState");
-                                            errActivate = NativeImports.BluetoothSetServiceState(radio, ref deviceInfo, ref HidServiceClass, 0x01);
+                                            errActivate = NativeImports.BluetoothSetServiceState(radio, in deviceInfo, in NativeImports.HidServiceClassGuid, 0x01);
                                             WiitarDebug.Log("AFT - BluetoothSetServiceState");
                                             success = errActivate == 0;
                                         }

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -107,15 +107,10 @@ namespace WiitarThing.Windows
                     {
                         if (device.Name.StartsWith("Nintendo RVL-CNT-01"))
                         {
-                            //NativeImports.BluetoothRemoveDevice(ref deviceInfo.Address);
-
-                            //StringBuilder password = new StringBuilder();
-                            ////uint pcService = 16;
-                            ////Guid[] guids = new Guid[16];
                             bool success = true;
                             uint errForget = 0;
 
-                            if (/*!ConnectedDeviceAddresses.Contains(deviceInfo.Address) && */(device.Remembered || device.Connected))
+                            if (device.Remembered || device.Connected)
                             {
                                 WiitarDebug.Log("BEF - BluetoothRemoveDevice");
                                 errForget = device.Remove();
@@ -183,16 +178,6 @@ namespace WiitarThing.Windows
                             }
 
                             bool remembered = device.Remembered;
-//#if DEBUG
-//                          var str_fRemembered = remembered ? ", but it is already synced!" : "";
-//#else
-//                          if (remembered)
-//                          {
-//                              continue;
-//                          }
-//                          var str_fRemembered = "";
-//#endif
-
                             var str_fRemembered = remembered ? ", but it is already synced!" : ". Attempting to pair now...";
 
                             if (deviceName.Equals("Nintendo RVL-CNT-01"))
@@ -245,30 +230,14 @@ namespace WiitarThing.Windows
                                     password.Append((char)bytes[i]);
                             }
 
-                            uint errForget = 0;
                             uint errAuth = 0;
                             uint errService = 0;
                             uint errActivate = 0;
-
-
-                            //if (/*!ConnectedDeviceAddresses.Contains(deviceInfo.Address) && */(deviceInfo.fRemembered || deviceInfo.fConnected))
-                            //{
-                            //    // Remove current pairing
-                            //    Prompt("Device already in Bluetooth devices list. Removing from list before trying to sync...");
-                            //    errForget = NativeImports.BluetoothRemoveDevice(ref deviceInfo.Address);
-                            //    success = errForget == 0;
-
-                            //    if (success)
-                            //    {
-                            //        OnNewDeviceFound();
-                            //    }
-                            //}
 
                             // Authenticate
                             if (success)
                             {
                                 errAuth = device.Authenticate(password.ToString());
-                                //errAuth = NativeImports.BluetoothAuthenticateDeviceEx(IntPtr.Zero, radio, in deviceInfo, null, NativeImports.AUTHENTICATION_REQUIREMENTS.MITMProtectionNotRequired);
                                 success = errAuth == 0;
                             }
 
@@ -290,7 +259,6 @@ namespace WiitarThing.Windows
                                 }
 
                                 errAuth = device.Authenticate(password.ToString());
-                                //errAuth = NativeImports.BluetoothAuthenticateDeviceEx(IntPtr.Zero, radio, in deviceInfo, null, NativeImports.AUTHENTICATION_REQUIREMENTS.MITMProtectionNotRequired);
                                 success = errAuth == 0;
                             }
 
@@ -320,7 +288,6 @@ namespace WiitarThing.Windows
                             else
                             {
                                 var sb = new StringBuilder();
-                                //sb.AppendLine("Failed to pair.");
 
 #if DEBUG
                                 sb.AppendLine("radio mac address: " + GetMacAddressStr(radioInfo.address));
@@ -328,11 +295,6 @@ namespace WiitarThing.Windows
                                 sb.AppendLine("wiimote password: \"" + password.ToString() + "\"");
 #endif
 
-                                
-                                if (errForget != 0)
-                                {
-                                    sb.AppendLine(" >>> FAILED TO REMOVE DEVICE FROM BLUETOOTH DEVICES LIST. ERROR CODE 0x" + errForget.ToString("X"));
-                                }
 
                                 if (errAuth != 0)
                                 {
@@ -402,23 +364,8 @@ namespace WiitarThing.Windows
                 prompt.Blocks.Add(newParagraph);
 
                 promptBoxContainer.ScrollToEnd();
-
-                //if (prompt.LineCount > 0)
-                //    prompt.ScrollToLine(prompt.LineCount - 1);
-                //prompt.ScrollToEnd();
             }));
         }
-
-        //private void SetPrompt(string text)
-        //{
-        //    Dispatcher.BeginInvoke(new Action(() =>
-        //    {
-        //        prompt.Text = text;
-        //        if (prompt.LineCount > 0)
-        //            prompt.ScrollToLine(prompt.LineCount - 1);
-        //        //prompt.ScrollToEnd();
-        //    }));
-        //}
 
         private void cancelBtn_Click(object sender, RoutedEventArgs e)
         {

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -6,6 +6,7 @@ using System.Windows;
 using Shared.Windows;
 using System.ComponentModel;
 using System.Windows.Interop;
+using System.Linq;
 
 namespace WiitarThing.Windows
 {
@@ -262,22 +263,26 @@ namespace WiitarThing.Windows
                                 success = errAuth == 0;
                             }
 
-                            // Install PC Service
+                            // Get activated services
+                            Guid[] guids = null;
                             if (success)
                             {
                                 WiitarDebug.Log("BEF - BluetoothEnumerateInstalledServices");
-                                errService = device.EnumerateInstalledServices(out var guids);
+                                errService = device.EnumerateInstalledServices(out guids);
                                 WiitarDebug.Log("AFT - BluetoothEnumerateInstalledServices");
                                 success = errService == 0;
                             }
 
-                            // Set to HID service
+                            // Activate HID service
                             if (success)
                             {
-                                WiitarDebug.Log("BEF - BluetoothSetServiceState");
-                                errActivate = device.SetServiceState(NativeImports.HidServiceClassGuid, true);
-                                WiitarDebug.Log("AFT - BluetoothSetServiceState");
-                                success = errActivate == 0;
+                                if (guids == null || !guids.Contains(NativeImports.HidServiceClassGuid))
+                                {
+                                    WiitarDebug.Log("BEF - BluetoothSetServiceState");
+                                    errActivate = device.SetServiceState(NativeImports.HidServiceClassGuid, true);
+                                    WiitarDebug.Log("AFT - BluetoothSetServiceState");
+                                    success = errActivate == 0;
+                                }
                             }
 
                             if (success)

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -79,23 +79,18 @@ namespace WiitarThing.Windows
         {
             var password = new StringBuilder();
             byte[] bytes = BitConverter.GetBytes(address);
-            // TODO: Does endianness matter?
             if (BitConverter.IsLittleEndian)
             {
                 for (int i = 0; i < 6; i++)
                 {
-                    // TODO: Is this check necessary?
-                    if (bytes[i] > 0)
-                        password.Append((char)bytes[i]);
+                    password.Append((char)bytes[i]);
                 }
             }
             else
             {
                 for (int i = 7; i >= 2; i--)
                 {
-                    // TODO: Is this check necessary?
-                    if (bytes[i] > 0)
-                        password.Append((char)bytes[i]);
+                    password.Append((char)bytes[i]);
                 }
             }
 

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -121,13 +121,12 @@ namespace WiitarThing.Windows
             var btRadios = BluetoothRadio.FindAllRadios();
             if (btRadios.Count > 0)
             {
-                foreach (var radio in btRadios)
+                foreach (var radio in btRadios) using (radio)
                 {
                     // Get devices on this radio
                     var devices = radio.FindAllDevices();
                     if (devices == null || devices.Count < 1)
                     {
-                        radio.Dispose();
                         continue;
                     }
                     
@@ -155,8 +154,6 @@ namespace WiitarThing.Windows
                         }
 
                     }
-
-                    radio.Dispose();
                 }
             }
 
@@ -175,13 +172,12 @@ namespace WiitarThing.Windows
                 // Search until cancelled or at least one device is paired
                 while (!Cancelled && Count == 0)
                 {
-                    foreach (var radio in btRadios)
+                    foreach (var radio in btRadios) using (radio)
                     {
                         // Get radio info
                         if (!radio.TryGetInfo(out var radioInfo))
                         {
                             Prompt("Found Bluetooth adapter but was unable to interact with it.");
-                            radio.Dispose();
                             continue;
                         }
 
@@ -189,7 +185,6 @@ namespace WiitarThing.Windows
                         var devices = radio.FindAllDevices();
                         if (devices == null || devices.Count < 1)
                         {
-                            radio.Dispose();
                             continue;
                         }
                         
@@ -313,8 +308,6 @@ namespace WiitarThing.Windows
                                 Prompt(sb.ToString(), isBold: true, isItalic: true);
                             }
                         }
-
-                        radio.Dispose();
                     }
                 }
             }

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -64,15 +64,6 @@ namespace WiitarThing.Windows
             }
 
             return msg;
-        }
-
-        static string GetMacAddressStr(ulong address)
-        {
-            var bytes = BitConverter.GetBytes(address);
-            StringBuilder str = new StringBuilder();
-            for (int i = 0; i < 6; i++)
-                str.Append(bytes[i].ToString("X2") + " ");
-            return str.ToString();
         }
 
         static string GetPasswordFromMacAddress(ulong address)
@@ -279,9 +270,23 @@ namespace WiitarThing.Windows
                                 var sb = new StringBuilder();
 
 #if DEBUG
-                                sb.AppendLine("radio mac address: " + GetMacAddressStr(radioInfo.address));
-                                sb.AppendLine("wiimote mac address: " + GetMacAddressStr(device.Address));
-                                sb.AppendLine("wiimote password: \"" + password + "\"");
+                                sb.AppendLine($"radio mac address: {radioInfo.address:X12}");
+                                sb.AppendLine($"wiimote mac address: {device.Address:X12}");
+                                sb.Append($"wiimote password: \"{password}\" (");
+                                foreach (char ch in password)
+                                {
+                                    if (ch > byte.MaxValue)
+                                    {
+                                        sb.Append($"{ch & 0xFF:X2}-{(ch & 0xFF00) >> 8:X2}-");
+                                    }
+                                    else
+                                    {
+                                        sb.Append($"{ch:X2}-");
+                                    }
+                                }
+                                // Remove trailing dash
+                                sb.Remove(sb.Length - 1, 1);
+                                sb.AppendLine(")");
 #endif
 
 

--- a/WiitarThing/Windows/SyncWindow.xaml.cs
+++ b/WiitarThing/Windows/SyncWindow.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -104,6 +104,7 @@ namespace WiitarThing.Windows
             var radioParams = NativeImports.BLUETOOTH_FIND_RADIO_PARAMS.Create();
             Guid HidServiceClass = NativeImports.HidServiceClassGuid;
 
+            // Get Bluetooth radios
             var btRadios = BluetoothRadio.FindAllRadios();
             if (btRadios.Count > 0)
             {
@@ -116,6 +117,7 @@ namespace WiitarThing.Windows
                         continue;
                     }
                     
+                    // Remove all wiimotes that are connected or paired
                     foreach (var device in devices)
                     {
                         if (device.Name.StartsWith("Nintendo RVL-CNT-01"))
@@ -150,6 +152,7 @@ namespace WiitarThing.Windows
         {
             WiitarDebug.Log("FUNC BEGIN - Sync");
 
+            // Retrieve all radios on the system
             var btRadios = BluetoothRadio.FindAllRadios();
             if (btRadios.Count < 1)
             {
@@ -183,6 +186,7 @@ namespace WiitarThing.Windows
                     
                     foreach (var device in devices)
                     {
+                        // Check device name
                         // Note: Switch Pro Controller is simply called "Pro Controller"
                         string deviceName = device.Name;
                         if (!deviceName.StartsWith("Nintendo RVL-CNT-01"))
@@ -213,6 +217,7 @@ namespace WiitarThing.Windows
                             Prompt("Found Unknown Wii Device Type (\"" + deviceName + "\")" + str_fRemembered, isBold: !remembered, isItalic: remembered, isSmall: remembered);
                         }
 
+                        // Skip already-paired devices
                         if (remembered)
                         {
                             continue;
@@ -233,7 +238,7 @@ namespace WiitarThing.Windows
                             success = errAuth == 0;
                         }
 
-                        //If it fails using SYNC method, try 1+2 method.
+                        // If the sync method didn't work, try the 1+2 method
                         if (!success)
                         {
 #if DEBUG
@@ -318,6 +323,7 @@ namespace WiitarThing.Windows
                 }
             }
 
+            // Clean up radio handles
             foreach (var radio in btRadios)
             {
                 radio.Dispose();


### PR DESCRIPTION
Summary:

- Correct parameters and in/out/ref markings of Kernel32 and bthprops imports
- Remove GetLastError import, as using it directly is not recommended and can give incorrect results
- Encapsulate Bluetooth radio/device functionality into classes
- Create safe handles for Bluetooth search and radio handles
- Many cleanups and fixes to the sync window
  - Notably, respect CPU endianness (for robustness and futureproofing), don't ignore `\0` characters when getting password string, and check for the HID service being enabled before trying to enable it

Hoping this will resolve the "ACTIVATION ERROR: The parameter is not correct" issue and help with wiimotes that reject the pairing pin. It also fixes a bunch of handle leaks and a very dangerous incorrect import lol (how did this even work in the first place?)